### PR TITLE
Update `mqtt.server`

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -8,7 +8,7 @@ modules_version: ${mos.version}
 mongoose_os_version: ${mos.version}
 
 config_schema:
-  - ["mqtt.server", "iot.eclipse.org:1883"]
+  - ["mqtt.server", "mqtt.eclipseprojects.io:1883"]
   - ["i2c.enable", true]
 
 tags:


### PR DESCRIPTION
`iot.eclipse.org:1883` is not available anymore. The new server is `mqtt.eclipseprojects.io:1883` 
https://iot.eclipse.org/projects/sandboxes/